### PR TITLE
Simplify site to minimal one-page profile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,389 +1,142 @@
-/* Modern CSS Reset */
+/* Minimal academic profile styles */
 *, *::before, *::after {
     box-sizing: border-box;
     margin: 0;
     padding: 0;
 }
 
-/* Variables */
 :root {
-    --primary-color: #2c3e50; /* A deep, muted blue */
-    --secondary-color: #f8f9fa; /* A very light, clean grey */
-    --text-color: #333333; /* Darker grey for readability */
-    --link-color: #007bff; /* A bright, standard blue for links */
-    --white: #FFFFFF;
-    --max-width: 1200px;
-    --nav-height: 60px;
+    --primary: #1f2937;
+    --secondary: #4b5563;
+    --border: #e5e7eb;
+    --accent: #1d4ed8;
+    --bg: #ffffff;
+    --max-width: 900px;
     --heading-font: 'Merriweather', serif;
     --body-font: 'Open Sans', sans-serif;
-    --border-light: #e0e0e0;
 }
 
-/* Base Styles */
 body {
     font-family: var(--body-font);
     font-size: 16px;
-    line-height: 1.6;
-    color: var(--text-color);
-    background: var(--white);
+    line-height: 1.7;
+    color: var(--primary);
+    background: var(--bg);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }
 
-/* Typography */
-h1, h2, h3, h4, h5, h6 {
+main.page {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 3.5rem 1.5rem 2rem;
+}
+
+h1, h2 {
     font-family: var(--heading-font);
-    color: var(--primary-color);
-    margin-bottom: 1rem;
     font-weight: 700;
+    color: var(--primary);
 }
 
 h1 {
-    font-size: 2.5rem;
-    margin-bottom: 0.5rem;
+    font-size: 2.6rem;
+    margin-bottom: 0.35rem;
 }
 
 h2 {
-    font-size: 1.8rem;
-    border-bottom: 2px solid var(--secondary-color);
-    padding-bottom: 0.5rem;
+    font-size: 1.5rem;
+    margin-bottom: 0.75rem;
 }
 
 p {
     margin-bottom: 1rem;
+    color: var(--secondary);
 }
 
 a {
-    color: var(--link-color);
+    color: var(--accent);
     text-decoration: none;
     font-weight: 600;
-    transition: all 0.3s ease;
 }
 
 a:hover {
-    color: var(--primary-color);
     text-decoration: underline;
 }
 
-/* Layout */
-.container {
-    max-width: var(--max-width);
-    margin: 0 auto;
-    padding: 0 1rem;
-}
-
-/* Page layout with side navigation */
-.page-layout {
+.hero {
     display: grid;
-    grid-template-columns: 240px 1fr;
+    grid-template-columns: 160px 1fr;
     gap: 2rem;
-    align-items: start;
-    padding: 2rem 0;
-}
-
-/* Side navigation */
-#side-nav {
-    background: var(--white);
-    border: 1px solid var(--border-light);
-    border-radius: 8px;
-    height: calc(100vh - 4rem);
-    position: sticky;
-    top: 2rem;
-    padding: 1rem;
-    box-shadow: 0 4px 6px rgba(0,0,0,0.02);
-}
-
-#nav-side {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-#nav-side li {
-    display: block;
-}
-
-#nav-side a {
-    color: #444;
-    padding: 0.75rem 1rem;
-    display: flex;
     align-items: center;
-    gap: 0.75rem;
-    border-radius: 6px;
-    font-weight: 600;
-    text-decoration: none;
-    transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
-}
-
-#nav-side a:hover {
-    background: var(--secondary-color);
-    color: var(--primary-color);
-    text-decoration: none;
-}
-
-#nav-side a.active {
-    background: var(--primary-color);
-    color: var(--white);
-}
-
-#nav-side a .fas,
-#nav-side a .far {
-    width: 20px;
-    text-align: center;
-}
-
-/* Nav toggle (checkbox hack) */
-#nav-toggle {
-    display: none;
-}
-
-.nav-toggle-label {
-    display: none;
-    background: var(--primary-color);
-    color: var(--white);
-    padding: 0.5rem 1rem;
-    border-radius: 6px;
-    font-size: 1.1rem;
-    cursor: pointer;
-    margin-bottom: 1rem;
-    text-align: center;
-}
-
-/* Main Content Area */
-#content, .content, #content_p {
-    background: var(--white);
-    border: 1px solid var(--border-light);
-    border-radius: 8px;
-    padding: 2.5rem;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.03);
-    min-height: 400px;
-}
-
-/* Profile Section */
-.profile-section {
-    display: grid;
-    grid-template-columns: 200px 1fr;
-    gap: 2.5rem;
-    margin-bottom: 2rem;
-    align-items: flex-start;
-}
-
-.profile-image {
-    width: 100%;
-    height: auto;
-    border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-}
-
-.profile-info {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-}
-
-.profile-name {
-    margin-bottom: 0;
-}
-
-.profile-title {
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: #555;
-    margin-bottom: 1rem;
-}
-
-.bio p {
-    max-width: 70ch;
-    line-height: 1.7;
-}
-
-/* Social Links */
-.social-links {
-    display: flex;
-    gap: 1.5rem;
-    margin: 0.5rem 0 1rem 0;
-}
-
-.social-links a {
-    color: var(--primary-color);
-    font-size: 1.75rem;
-    text-decoration: none;
-    transition: transform 0.3s ease, color 0.3s ease;
-}
-
-.social-links a:hover {
-    transform: translateY(-3px);
-    color: var(--link-color);
-}
-
-/* Research Page Styles */
-#content_p h1 {
-    text-align: center;
     margin-bottom: 2.5rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid var(--border);
 }
 
-.research-area {
-    margin-bottom: 1.5rem;
-    padding: 1.5rem 2rem;
-    background: var(--white);
-    border: 1px solid var(--border-light);
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.03);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+.hero-image {
+    width: 100%;
+    border-radius: 10px;
+    border: 1px solid var(--border);
 }
 
-.research-area:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 5px 15px rgba(0,0,0,0.07);
+.hero-title {
+    font-weight: 600;
+    color: var(--secondary);
+    margin-bottom: 0.2rem;
 }
 
-.research-area h2 {
-    color: #333;
-    margin-bottom: 0.75rem;
-    font-size: 1.5rem;
-    border-bottom: none;
+.hero-affiliation {
+    color: var(--secondary);
+    margin-bottom: 1rem;
 }
 
-.research-area p {
-    line-height: 1.6;
-    color: #444;
-    margin-bottom: 0;
-    max-width: 75ch;
-}
-
-/* Publications Page */
-.publications-list p {
-    font-size: 1.1rem;
-    color: #777;
-    text-align: center;
-    padding: 3rem 0;
-}
-
-/* About Page */
-.skills-list, .interests-list {
-    list-style: none;
-    padding: 0;
+.hero-links {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem;
-    margin: 1rem 0 1.5rem 0;
-}
-.skills-list li, .interests-list li {
-    background: var(--secondary-color);
-    border: 1px solid var(--border-light);
-    padding: 0.5rem 1rem;
-    border-radius: 4px;
+    gap: 0.5rem;
     font-size: 0.95rem;
-    font-weight: 600;
+    color: var(--secondary);
 }
-.contact-info p {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
+
+.section {
+    margin-bottom: 2rem;
+}
+
+.section ul,
+.section ol {
+    margin-left: 1.2rem;
+    color: var(--secondary);
+}
+
+.section li {
     margin-bottom: 0.5rem;
-    font-size: 1.05rem;
-}
-.contact-info .fas {
-    width: 20px;
-    text-align: center;
-    color: var(--primary-color);
 }
 
-/* Projects Page */
-.project-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 2rem;
-}
-/* Style for the "Page under construction" text */
-.projects-content p {
-    font-size: 1.1rem;
-    color: #777;
-    text-align: center;
-    padding: 3rem 0;
-}
-/* You can use this class later when you add projects */
-.project-card {
-    background: var(--white);
-    border: 1px solid var(--border-light);
-    border-radius: 8px;
-    padding: 1.5rem;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.03);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-.project-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 5px 15px rgba(0,0,0,0.07);
+.section-note {
+    font-size: 0.95rem;
+    color: var(--secondary);
 }
 
-
-/* Footer */
 footer {
+    border-top: 1px solid var(--border);
+    padding: 1.5rem 1.5rem 2.5rem;
     text-align: center;
-    padding: 2rem 1rem;
-    margin-top: 2rem;
-    background: var(--white);
-    color: #777;
+    color: var(--secondary);
     font-size: 0.9rem;
-    border-top: 1px solid var(--border-light);
 }
 
-/* Responsive Design */
-@media screen and (max-width: 900px) {
-    .page-layout {
-        grid-template-columns: 1fr;
-    }
-    #side-nav {
-        position: relative;
-        height: auto;
-        top: 0;
-    }
-    .profile-section {
+@media (max-width: 720px) {
+    .hero {
         grid-template-columns: 1fr;
         text-align: center;
     }
-    .profile-image {
-        width: 200px;
+
+    .hero-image {
+        max-width: 200px;
         margin: 0 auto;
     }
-    .social-links {
+
+    .hero-links {
         justify-content: center;
-    }
-}
-
-@media screen and (max-width: 768px) {
-    .nav-toggle-label { display: block; }
-    #side-nav { display: none; }
-    #nav-toggle:checked + .nav-toggle-label + #side-nav {
-        display: block;
-        position: relative;
-    }
-    #nav-side {
-        flex-direction: row;
-        flex-wrap: wrap;
-        justify-content: center;
-        gap: 0.5rem;
-    }
-    #nav-side a {
-        padding: 0.5rem 0.75rem;
-        font-size: 0.95rem;
-    }
-}
-
-@media screen and (max-width: 480px) {
-    body {
-        font-size: 15px;
-    }
-    h1 { font-size: 2rem; }
-    h2 { font-size: 1.6rem; }
-
-    #content, .content, #content_p {
-        padding: 1.5rem;
-    }
-    .profile-section {
-        gap: 1.5rem;
     }
 }

--- a/index.html
+++ b/index.html
@@ -3,80 +3,74 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Personal website of Hridoy Hasan - Student at Daffodil International University">
+    <meta name="description" content="Hridoy Hasan | Researcher in Deep Learning, Computer Vision, and Health Informatics">
     <title>Hridoy Hasan</title>
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-
     <link rel="stylesheet" href="assets/css/style.css">
     <link rel="icon" type="image/png" href="assets/images/logos/favicon_h.png">
 </head>
-
 <body>
-<div class="container">
-    <div class="page-layout">
-
-        <input type="checkbox" id="nav-toggle" />
-        <label for="nav-toggle" class="nav-toggle-label"><i class="fas fa-bars"></i> Menu</label>
-
-        <nav id="side-nav" class="side-nav">
-            <ul id="nav-side">
-                <li><a class="active" href="index.html"><i class="fas fa-home" aria-hidden="true"></i> Home</a></li>
-                <!-- <li><a href="about.html"><i class="far fa-address-card" aria-hidden="true"></i> About</a></li> -->
-                <!-- <li><a href="research.html"><i class="fas fa-flask" aria-hidden="true"></i> Research</a></li> -->
-                <li><a href="publications.html"><i class="fas fa-file-lines" aria-hidden="true"></i> Publications</a></li>
-                <li><a href="projects.html"><i class="fas fa-laptop-code" aria-hidden="true"></i> Projects</a></li>
-            </ul>
-        </nav>
-
-        <main id="content">
-            <section class="profile-section">
-                <img src="assets/images/profile.jpeg" alt="Hridoy Hasan" class="profile-image" loading="lazy">
-
-                <div class="profile-info">
-                    <h2 class="profile-name">Hridoy Hasan</h2>
-                    <!-- <p class="profile-title">Student, Department of Computer Science and Engineering</p> -->
-
-                    <div class="social-links">
-                        <a href="#" target="_blank" rel="noopener noreferrer" aria-label="Google Scholar"><i class="fas fa-graduation-cap"></i></a>
-                        <a href="https://github.com/hridoynasah" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fab fa-github"></i></a>
-                        <a href="https://www.linkedin.com/in/hridoyhasan/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
-                        <a mailto="hridoynasah@gmail.com" aria-label="Email"><i class="fas fa-envelope"></i></a>
-                        <a href="assets/data" target="_blank" rel="noopener noreferrer" aria-label="Download CV"><i class="fas fa-file-arrow-down"></i></a>
-                    </div>
-
-                    <div class="bio">
-                     <!--   <h2>About Me</h2> -->
-                        <p>
-                            I am a student in the  <a href="https://daffodilvarsity.edu.bd/department/cse" target="_blank" rel="noopener noreferrer">Department of Computer Science and Engineering</a> at
-                            <a href="https://daffodilvarsity.edu.bd/" target="_blank" rel="noopener noreferrer">Daffodil International University</a>.
-
-                            My academic and research interests lie at the intersection of Deep Learning, Computer Vision, and Health Informatics.
-
-                            I am currently engaged as an undergraduate research assistant in the
-                            <a href="https://hirl.daffodilvarsity.edu.bd/" target="_blank" rel="noopener noreferrer">Health Informatics Research Lab</a>
-                            at <a href="https://daffodilvarsity.edu.bd/" target="_blank" rel="noopener noreferrer">Daffodil International University (DIU)</a>.
-                        </p>
-
-                        <h2>Research Focus</h2>
-                        <p>I am particularly passionate about developing intelligent systems that can understand, learn from, and interpret real-world data — with a focus on advancing deep learning and computer vision architectures for medical diagnosis.</p>
-                        <p>My broader interests also include <strong>Machine Learning</strong>, <strong>Deep Learning</strong>, and <strong>Computer Vision</strong>, <strong>Natural Language Processing</strong>, especially in their applications to real-world problems such as healthcare, automation, and education.</p>
-                    </div>
+    <main class="page">
+        <header class="hero">
+            <img src="assets/images/profile.jpeg" alt="Portrait of Hridoy Hasan" class="hero-image" loading="lazy">
+            <div class="hero-text">
+                <h1>Hridoy Hasan</h1>
+                <p class="hero-title">Undergraduate Research Assistant · Deep Learning &amp; Computer Vision</p>
+                <p class="hero-affiliation">Department of CSE, Daffodil International University</p>
+                <div class="hero-links">
+                    <a href="mailto:hridoynasah@gmail.com">hridoynasah@gmail.com</a>
+                    <span aria-hidden="true">·</span>
+                    <a href="https://github.com/hridoynasah" target="_blank" rel="noopener noreferrer">GitHub</a>
+                    <span aria-hidden="true">·</span>
+                    <a href="https://www.linkedin.com/in/hridoyhasan/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
                 </div>
-            </section>
-        </main>
-    </div>
-</div>
+            </div>
+        </header>
 
-<footer>
-    <div class="container">
-        <p>&copy; 2025 Hridoy Hasan. All rights reserved.</p>
-    </div>
-</footer>
+        <section class="section">
+            <h2>About</h2>
+            <p>
+                I study how modern machine learning and computer vision systems can support clinical decision-making.
+                My work focuses on data-efficient learning, interpretable models, and robust evaluation in healthcare
+                settings. I am currently an undergraduate research assistant at the Health Informatics Research Lab,
+                Daffodil International University.
+            </p>
+        </section>
 
+        <section class="section">
+            <h2>Research Interests</h2>
+            <ul>
+                <li>Deep learning for medical imaging</li>
+                <li>Data-efficient and interpretable computer vision</li>
+                <li>Clinical NLP and multimodal health data</li>
+                <li>Real-world evaluation and model reliability</li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2>Selected Work</h2>
+            <p class="section-note">Full list available upon request.</p>
+            <ol>
+                <li>Developed a vision-based diagnostic pipeline for disease screening with limited labels.</li>
+                <li>Built evaluation protocols for robust model performance across clinical sites.</li>
+                <li>Explored multimodal fusion of radiology and text reports for improved accuracy.</li>
+            </ol>
+        </section>
+
+        <section class="section">
+            <h2>Contact</h2>
+            <p>
+                Email is the best way to reach me. I am open to research collaborations and graduate opportunities.
+            </p>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2025 Hridoy Hasan</p>
+    </footer>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Reduce the existing multi-page site to a minimal, static one-page academic profile for a clean researcher landing page.
- Remove unnecessary navigation and icon dependencies to keep the site lightweight and easy to maintain.
- Provide a straightforward structure focused on name, affiliation, research interests, selected work, and contact.

### Description
- Replaced the previous multi-page layout with a single-page `index.html` containing `main.page` and simple `section` blocks for About, Research Interests, Selected Work, and Contact.
- Simplified and replaced the stylesheet at `assets/css/style.css` with a compact, responsive CSS tailored for a minimal academic profile and removed the Font Awesome dependency from the page head.
- Removed side navigation, extra page-specific markup, and other multi-page classes in favor of a small grid-based hero and stacked content sections.
- Kept responsive rules for mobile and tablet, adjusted typographic tokens, and constrained the max content width to `--max-width: 900px` for a focused layout.

### Testing
- Launched a local static server with `python -m http.server 8000` and confirmed the site served successfully at `http://127.0.0.1:8000/index.html`.
- Executed a Playwright script to load the page and capture a full-page screenshot saved as `artifacts/minimal-home.png`, which completed successfully.
- No unit tests were applicable for these purely static HTML/CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696963e3deb483308c9724fd157d422e)