### PR TITLE
Refine academic single-page layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,20 +6,20 @@
 }
 
 :root {
-    --primary: #1f2937;
+    --primary: #111827;
     --secondary: #4b5563;
     --border: #e5e7eb;
     --accent: #1d4ed8;
     --bg: #ffffff;
-    --max-width: 900px;
+    --max-width: 960px;
     --heading-font: 'Merriweather', serif;
     --body-font: 'Open Sans', sans-serif;
 }
 
 body {
     font-family: var(--body-font);
-    font-size: 16px;
-    line-height: 1.7;
+    font-size: 15.5px;
+    line-height: 1.6;
     color: var(--primary);
     background: var(--bg);
     -webkit-font-smoothing: antialiased;
@@ -29,7 +29,7 @@ body {
 main.page {
     max-width: var(--max-width);
     margin: 0 auto;
-    padding: 3.5rem 1.5rem 2rem;
+    padding: 3rem 1.5rem 2rem;
 }
 
 h1, h2 {
@@ -39,17 +39,18 @@ h1, h2 {
 }
 
 h1 {
-    font-size: 2.6rem;
-    margin-bottom: 0.35rem;
+    font-size: 2.4rem;
+    margin-bottom: 0.4rem;
 }
 
 h2 {
-    font-size: 1.5rem;
-    margin-bottom: 0.75rem;
+    font-size: 1.2rem;
+    letter-spacing: 0.01em;
+    margin-bottom: 0.6rem;
 }
 
 p {
-    margin-bottom: 1rem;
+    margin-bottom: 0.9rem;
     color: var(--secondary);
 }
 
@@ -65,46 +66,67 @@ a:hover {
 
 .hero {
     display: grid;
-    grid-template-columns: 160px 1fr;
-    gap: 2rem;
+    grid-template-columns: 140px 1fr;
+    gap: 1.5rem;
     align-items: center;
-    margin-bottom: 2.5rem;
-    padding-bottom: 2rem;
+    padding-bottom: 1.75rem;
     border-bottom: 1px solid var(--border);
 }
 
 .hero-image {
     width: 100%;
-    border-radius: 10px;
+    border-radius: 8px;
     border: 1px solid var(--border);
+}
+
+.hero-kicker {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--secondary);
+    margin-bottom: 0.35rem;
 }
 
 .hero-title {
     font-weight: 600;
     color: var(--secondary);
-    margin-bottom: 0.2rem;
+    margin-bottom: 0.25rem;
 }
 
 .hero-affiliation {
     color: var(--secondary);
-    margin-bottom: 1rem;
+    margin-bottom: 0.6rem;
 }
 
 .hero-links {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
-    font-size: 0.95rem;
+    gap: 0.4rem;
+    font-size: 0.9rem;
     color: var(--secondary);
 }
 
+.content-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+    gap: 1.5rem 2.5rem;
+    padding-top: 1.75rem;
+}
+
 .section {
-    margin-bottom: 2rem;
+    padding-top: 1.1rem;
+    border-top: 1px solid var(--border);
+}
+
+.section:first-child,
+.section:nth-child(2) {
+    border-top: none;
+    padding-top: 0;
 }
 
 .section ul,
 .section ol {
-    margin-left: 1.2rem;
+    margin-left: 1.1rem;
     color: var(--secondary);
 }
 
@@ -112,17 +134,18 @@ a:hover {
     margin-bottom: 0.5rem;
 }
 
-.section-note {
-    font-size: 0.95rem;
-    color: var(--secondary);
-}
-
 footer {
     border-top: 1px solid var(--border);
     padding: 1.5rem 1.5rem 2.5rem;
     text-align: center;
     color: var(--secondary);
-    font-size: 0.9rem;
+    font-size: 0.85rem;
+}
+
+@media (max-width: 820px) {
+    .hero {
+        grid-template-columns: 120px 1fr;
+    }
 }
 
 @media (max-width: 720px) {
@@ -132,11 +155,25 @@ footer {
     }
 
     .hero-image {
-        max-width: 200px;
+        max-width: 180px;
         margin: 0 auto;
     }
 
     .hero-links {
         justify-content: center;
+    }
+
+    .content-grid {
+        grid-template-columns: 1fr;
+        gap: 1.25rem;
+    }
+
+    .section {
+        border-top: 1px solid var(--border);
+    }
+
+    .section:first-child {
+        border-top: none;
+        padding-top: 0;
     }
 }

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <header class="hero">
             <img src="assets/images/profile.jpeg" alt="Portrait of Hridoy Hasan" class="hero-image" loading="lazy">
             <div class="hero-text">
+                <p class="hero-kicker">Academic Profile</p>
                 <h1>Hridoy Hasan</h1>
                 <p class="hero-title">Undergraduate Research Assistant · Deep Learning &amp; Computer Vision</p>
                 <p class="hero-affiliation">Department of CSE, Daffodil International University</p>
@@ -31,42 +32,42 @@
             </div>
         </header>
 
-        <section class="section">
-            <h2>About</h2>
-            <p>
-                I study how modern machine learning and computer vision systems can support clinical decision-making.
-                My work focuses on data-efficient learning, interpretable models, and robust evaluation in healthcare
-                settings. I am currently an undergraduate research assistant at the Health Informatics Research Lab,
-                Daffodil International University.
-            </p>
-        </section>
+        <div class="content-grid">
+            <section class="section">
+                <h2>Bio</h2>
+                <p>
+                    I investigate how data-efficient machine learning and computer vision can improve clinical
+                    decision-making, with emphasis on interpretable models and dependable evaluation in healthcare
+                    environments.
+                </p>
+            </section>
 
-        <section class="section">
-            <h2>Research Interests</h2>
-            <ul>
-                <li>Deep learning for medical imaging</li>
-                <li>Data-efficient and interpretable computer vision</li>
-                <li>Clinical NLP and multimodal health data</li>
-                <li>Real-world evaluation and model reliability</li>
-            </ul>
-        </section>
+            <section class="section">
+                <h2>Research Interests</h2>
+                <ul>
+                    <li>Medical image understanding and diagnosis support</li>
+                    <li>Interpretable, data-efficient computer vision</li>
+                    <li>Multimodal clinical data and report fusion</li>
+                    <li>Reliability and generalization in real-world settings</li>
+                </ul>
+            </section>
 
-        <section class="section">
-            <h2>Selected Work</h2>
-            <p class="section-note">Full list available upon request.</p>
-            <ol>
-                <li>Developed a vision-based diagnostic pipeline for disease screening with limited labels.</li>
-                <li>Built evaluation protocols for robust model performance across clinical sites.</li>
-                <li>Explored multimodal fusion of radiology and text reports for improved accuracy.</li>
-            </ol>
-        </section>
+            <section class="section">
+                <h2>Selected Publications &amp; Projects</h2>
+                <ol>
+                    <li>Vision-based screening pipeline for disease detection with limited labels.</li>
+                    <li>Cross-site evaluation protocols to stress-test clinical model robustness.</li>
+                    <li>Multimodal fusion of imaging and text reports for improved diagnostic accuracy.</li>
+                </ol>
+            </section>
 
-        <section class="section">
-            <h2>Contact</h2>
-            <p>
-                Email is the best way to reach me. I am open to research collaborations and graduate opportunities.
-            </p>
-        </section>
+            <section class="section">
+                <h2>Contact</h2>
+                <p>
+                    For research collaborations or graduate opportunities, email is the best way to connect.
+                </p>
+            </section>
+        </div>
     </main>
 
     <footer>


### PR DESCRIPTION
### Motivation
- Reorganize the homepage into a compact, single-page academic profile with clear headings (Bio, Research Interests, Selected Publications & Projects, Contact) and tighter vertical rhythm. 
- Emphasize concise bio and focused lists while keeping styling CSS-only and without animations.

### Description
- Update `index.html` to add an academic kicker, tighten hero content, rename and consolidate sections, and wrap content in a two-column `.content-grid` for a compact layout. 
- Update `assets/css/style.css` to adjust typography, spacing, grid/column widths, section dividers, and responsive rules (font sizes, line-height, hero grid, `.content-grid`, `.hero-kicker`, and section top borders). 
- Removed the previous `section-note` and adjusted small copy/details to fit the new layout. 
- Files changed: `index.html` and `assets/css/style.css`.

### Testing
- Launched a local static server with `python -m http.server 8000` and rendered the updated page headlessly using Playwright to capture a full-page screenshot, which completed successfully and produced `artifacts/academic-layout.png`.
- No unit tests were added or run for these static content/CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696967c1eab48330bbd4dd575c5e05da)